### PR TITLE
Fix broken link for crazyflie2.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This repository contains code supporting Pixhawk standard boards (best supported
   * [Hex Cube Yellow](https://docs.px4.io/master/en/flight_controller/cubepilot_cube_yellow.html)
   * [Airmind MindPX V2.8](http://www.mindpx.net/assets/accessories/UserGuide_MindPX.pdf)
   * [Airmind MindRacer V1.2](http://mindpx.net/assets/accessories/mindracer_user_guide_v1.2.pdf)
-  * [Bitcraze Crazyflie 2.0](https://docs.px4.io/master/en/flight_controller/crazyflie2.html)
+  * [Bitcraze Crazyflie 2.0](https://docs.px4.io/master/en/complete_vehicles/crazyflie2.html)
   * [Omnibus F4 SD](https://docs.px4.io/master/en/flight_controller/omnibus_f4_sd.html)
   * [Holybro Kakute F7](https://docs.px4.io/master/en/flight_controller/kakutef7.html)
   * [Raspberry PI with Navio 2](https://docs.px4.io/master/en/flight_controller/raspberry_pi_navio2.html)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Found a broken link in README.md under 'manufacturer and community supported' vehicles. The bitcraze crazyflie2.0 link is broken.

**Describe your solution**
Fixed broken link for bitcraze crazyflie 2.0 in README.md. New link: https://docs.px4.io/master/en/complete_vehicles/crazyflie2.html
